### PR TITLE
10/4 (날짜로 제품 노출유무 가르기, 사장님 로그인 이리저리 할 때 생기는 메뉴 혼선문제 해결)

### DIFF
--- a/src/Routes/admin/profile/index.tsx
+++ b/src/Routes/admin/profile/index.tsx
@@ -104,6 +104,7 @@ const SellerProfilePage: React.FC = () => {
     logoutAdmin();
     changeLastPage();
     navigate("/");
+    window.location.reload();
   };
 
   if (loading) return <p>로딩중입니다...</p>;

--- a/src/Routes/admin/sales/index.tsx
+++ b/src/Routes/admin/sales/index.tsx
@@ -129,12 +129,9 @@ const SalesPage: React.FC = () => {
   const formatDateToKST = (dateString: string) => {
     const date = new Date(dateString);
     const options: Intl.DateTimeFormatOptions = {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
+      month: "numeric", // 월을 숫자로
+      day: "numeric", // 일을 숫자로
+      weekday: "short", // 요일을 짧은 형태로 (월, 화, 수 등)
       timeZone: "Asia/Seoul", // KST (UTC+9)
     };
     return new Intl.DateTimeFormat("ko-KR", options).format(date);
@@ -218,7 +215,7 @@ const SalesPage: React.FC = () => {
                     </p>
                     {/* CreatedAt */}
                     <p className="text-gray-600 text-sm">
-                      등록일: {formatDateToKST(product.createdAt)}
+                      {formatDateToKST(product.createdAt)}
                     </p>
                   </div>
                 </div>

--- a/src/Routes/admin/sales/index.tsx
+++ b/src/Routes/admin/sales/index.tsx
@@ -26,6 +26,7 @@ const GET_PRODUCTS = gql`
         }
         isCanceled
       }
+      createdAt
     }
   }
 `;
@@ -124,6 +125,21 @@ const SalesPage: React.FC = () => {
       clearInterval(countdownId); // 컴포넌트가 언마운트될 때 interval 정리
     };
   }, []);
+
+  const formatDateToKST = (dateString: string) => {
+    const date = new Date(dateString);
+    const options: Intl.DateTimeFormatOptions = {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      timeZone: "Asia/Seoul", // KST (UTC+9)
+    };
+    return new Intl.DateTimeFormat("ko-KR", options).format(date);
+  };
+
   if (!store)
     return (
       <div className="flex flex-col items-center justify-center h-screen bg-gray-100">
@@ -199,6 +215,10 @@ const SalesPage: React.FC = () => {
                               10
                           ).toLocaleString()}
                       원<span className="text-sm text-gray-900">(10%)</span>
+                    </p>
+                    {/* CreatedAt */}
+                    <p className="text-gray-600 text-sm">
+                      등록일: {formatDateToKST(product.createdAt)}
                     </p>
                   </div>
                 </div>

--- a/src/Routes/home/index.tsx
+++ b/src/Routes/home/index.tsx
@@ -212,6 +212,7 @@ const Home = () => {
   // // setMsg3("web: ", isWeb());
   return (
     <div className="w-full h-[100vh] flex flex-col bg-white">
+      {/* <div onClick={() => localStorage.clear()}>clear</div> */}
       {/* LOCATION */}
       {/* <a
         className="h-4 ml-2 px-1.5 rounded-3xl text-2xs bg-[#f4f5f7] text-[#969696] mb-4"

--- a/src/Routes/home/index.tsx
+++ b/src/Routes/home/index.tsx
@@ -34,6 +34,15 @@ const GET_STORES = gql(`
         createdAt
         updatedAt
       }
+      todaysProducts {
+        id
+        price
+        discountPrice
+        saleEndTime
+        quantity
+        createdAt
+        updatedAt
+      }
       img
       contactNumber
       closingHours
@@ -326,14 +335,14 @@ const Home = () => {
               <div className="mb-4">
                 <StoreCard
                   title={store?.title as string}
-                  quantity={store?.products?.reduce((total, product) => {
+                  quantity={store?.todaysProducts?.reduce((total, product) => {
                     return total + product.quantity;
                   }, 0)}
                   closingHours={store?.closingHours as string}
                   discountPrice={
-                    (store?.products as Product[])[0]?.discountPrice
+                    (store?.todaysProducts as Product[])[0]?.discountPrice
                   }
-                  price={(store?.products as Product[])[0]?.price}
+                  price={(store?.todaysProducts as Product[])[0]?.price}
                   isLiked={store?.isLiked}
                   img={store?.img as string}
                   onClick={() => onClickStore(store?.id as number)}

--- a/src/Routes/onboarding/onboarding2.tsx
+++ b/src/Routes/onboarding/onboarding2.tsx
@@ -1,9 +1,12 @@
 import { useNavigate } from "react-router-dom";
 import IMG from "./bell3.png";
 import FadeInWrapper from "../../components/fade-in-wrapper";
+import { postMessage } from "../../core/message";
 const Onboarding2 = () => {
   const navigate = useNavigate();
   const onClickButton = () => {
+    // TODO: 다음 앱 심사 때 넣어서 나가야함.
+    // postMessage("REQ_NOTIFICATION", "");
     navigate("/welcome");
   };
 

--- a/src/Routes/store/index.tsx
+++ b/src/Routes/store/index.tsx
@@ -50,6 +50,26 @@ const GET_STORE = gql(`
           }
         }
       }
+      todaysProducts{
+        id
+        name
+        price
+        discountPrice
+        userPrice
+        img
+        isDeleted
+        saleEndTime
+        quantity
+        menus {
+          id
+          img
+          menu {
+            id
+            name
+            img
+          }
+        }
+      }
       img
       contactNumber
       closingHours
@@ -66,7 +86,7 @@ const Store = () => {
     variables: {
       storeId: Number(id),
     },
-    onCompleted: (data) => console.log(data.store?.products),
+    onCompleted: (data) => console.log(data.store?.todaysProducts),
     fetchPolicy: "network-only",
   });
   const store = data?.store;
@@ -313,7 +333,7 @@ const Store = () => {
 
           <Partition color="light" height="thick" />
 
-          {store.products?.length === 0 ? (
+          {store.todaysProducts?.length === 0 ? (
             <NoProduct
               isLiked={store.isLiked}
               onClickButton={async (e) => {
@@ -326,7 +346,7 @@ const Store = () => {
             />
           ) : (
             <div className="w-full p-5 pb-20 h-full gap-y-5 relative flex flex-col ">
-              {store?.products
+              {store?.todaysProducts
                 ?.filter(
                   (product) =>
                     product.isDeleted === false || product.isDeleted === null


### PR DESCRIPTION
1. 소비자들이 오늘 올라온 제품만 볼 수 있음!
- 서버에서 쿼리를 아예 새로 만듬. 
- client에서는 그걸 갈아낌 `products` -> `todaysProducts` 

2. 사장님 계정 이것저것 로그인-로그아웃 하면 생기던 메뉴 혼선 문제해결
- 원인:  핸드폰을 껐다 키거나 웹뷰를 새로고침하지 않으면 로컬스토리지에 `sellerToken` 갱신이 안됨.
- solution: 로그아웃할때, `window.location.reload` 탑재

3. 다음 앱심사때 앱으로 `REQ_NOTIFICATION` 보낼 수 있도록 주석 추가.